### PR TITLE
feat: adapt new mteam api

### DIFF
--- a/site/all/all.go
+++ b/site/all/all.go
@@ -4,6 +4,7 @@ import (
 	_ "github.com/sagan/ptool/site/discuz"
 	_ "github.com/sagan/ptool/site/gazelle"
 	_ "github.com/sagan/ptool/site/gazellepw"
+	_ "github.com/sagan/ptool/site/mtorrent"
 	_ "github.com/sagan/ptool/site/nexusphp"
 	_ "github.com/sagan/ptool/site/tnode"
 	_ "github.com/sagan/ptool/site/torrenttrader"

--- a/site/mtorrent/json.go
+++ b/site/mtorrent/json.go
@@ -1,0 +1,69 @@
+package mtorrent
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+type Time struct {
+	time.Time
+}
+
+func (ct *Time) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, ct.Format(time.DateTime))), nil
+}
+
+func (ct *Time) UnmarshalJSON(data []byte) error {
+	parsedTime, err := time.Parse(time.DateTime, string(data[1:len(data)-1]))
+	if err != nil {
+		return err
+	}
+	ct.Time = parsedTime
+	return nil
+}
+
+func (ct *Time) UnixWithDefault(defaultValue int64) int64 {
+	if ct == nil {
+		return defaultValue
+	}
+
+	return ct.Unix()
+}
+
+type Int64 int64
+
+func (ci *Int64) UnmarshalJSON(data []byte) error {
+	var raw json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	var num int64
+	if err := json.Unmarshal(raw, &num); err == nil {
+		*ci = Int64(num)
+		return nil
+	}
+
+	var str string
+	if err := json.Unmarshal(raw, &str); err != nil {
+		return err
+	}
+
+	num, err := strconv.ParseInt(str, 10, 64)
+	if err != nil {
+		return err
+	}
+
+	*ci = Int64(num)
+	return nil
+}
+
+func (ci *Int64) MarshalJSON() ([]byte, error) {
+	return json.Marshal(strconv.FormatInt(int64(*ci), 10))
+}
+
+func (ci *Int64) Value() int64 {
+	return int64(*ci)
+}

--- a/site/mtorrent/mtorrent.go
+++ b/site/mtorrent/mtorrent.go
@@ -1,0 +1,272 @@
+package mtorrent
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/Noooste/azuretls-client"
+	"github.com/sagan/ptool/config"
+	"github.com/sagan/ptool/site"
+	"github.com/sagan/ptool/util"
+	log "github.com/sirupsen/logrus"
+	"net"
+	"net/http"
+	neturl "net/url"
+)
+
+const (
+	APIPath_GenerateDownloadToken = "/api/torrent/genDlToken"
+	APIPath_TorrentSearch         = "/api/torrent/search"
+	APIPath_Profile               = "/api/member/profile"
+)
+
+var (
+	// sortFields: https://test2.m-team.cc/api/doc.html#/%E5%B8%B8%E8%A7%84%E6%8E%A5%E5%8F%A3/%E7%A8%AE%E5%AD%90/search
+	sortFields = map[string]string{
+		"time": "CREATED_DATE",
+		"size": "SIZE",
+	}
+)
+
+var _ site.Site = (*Site)(nil)
+
+type Site struct {
+	Name        string
+	SiteConfig  *config.SiteConfigStruct
+	HttpClient  *azuretls.Session
+	HttpHeaders [][]string
+}
+
+func (m *Site) GetName() string {
+	return m.Name
+}
+
+func (m *Site) GetDefaultHttpHeaders() [][]string {
+	return m.HttpHeaders
+}
+
+func (m *Site) GetSiteConfig() *config.SiteConfigStruct {
+	return m.SiteConfig
+}
+
+// DownloadTorrent download torrent by url like `https://kp.m-team.cc/api/rss/dl?credential=xxx`
+// if url is id, find real url by this id then call DownloadTorrentById
+func (m *Site) DownloadTorrent(url string) (content []byte, filename string, id string, err error) {
+	if !util.IsUrl(url) {
+		// not url, try id
+		id = url
+		content, filename, err = m.DownloadTorrentById(id)
+		return
+	}
+
+	content, filename, err = site.DownloadTorrentByUrl(m, m.HttpClient, url, id)
+	return
+}
+
+// DownloadTorrentById download torrent by id
+func (m *Site) DownloadTorrentById(id string) (content []byte, filename string, err error) {
+	q := make(neturl.Values)
+	q.Add("id", id)
+	var resp DownloadTokenResponse
+	if err = m.do(APIPath_GenerateDownloadToken, q, nil, &resp); err != nil {
+		err = fmt.Errorf("%s error: %w", APIPath_GenerateDownloadToken, err)
+		return
+	}
+
+	log.Tracef("download torrent url %v", resp.Data)
+	content, filename, err = site.DownloadTorrentByUrl(m, m.HttpClient, resp.Data, id)
+	return
+}
+
+func (m *Site) GetLatestTorrents(full bool) ([]site.Torrent, error) {
+	modes := []string{TorrentSearchMode_Normal}
+	if full {
+		modes = append(modes, TorrentSearchMode_Adult)
+	}
+
+	var mergedTorrents []site.Torrent
+	for _, mode := range modes {
+		if list, err := m.search(WithMode(mode)); err != nil {
+			log.Errorf("search mode %s failed: %v", mode, err)
+			continue
+		} else {
+			torrents := m.convertTorrents(list)
+			mergedTorrents = append(mergedTorrents, torrents...)
+		}
+	}
+
+	if len(mergedTorrents) == 0 {
+		return nil, fmt.Errorf("found 0 torrents")
+	}
+
+	return mergedTorrents, nil
+}
+
+func (m *Site) GetAllTorrents(sort string, desc bool, pageMarker string, baseUrl string) (torrents []site.Torrent, nextPageMarker string, err error) {
+	if sort != "" && sort != "none" && sortFields[sort] == "" {
+		err = fmt.Errorf("unsupported sort field: %s", sort)
+		return
+	}
+
+	var pageNumber int64 = 1
+	if pageMarker != "" {
+		pageNumber = util.ParseInt(pageMarker)
+	}
+
+	// pageNumber starts from 1, NOT 0
+	if pageNumber < 1 {
+		err = fmt.Errorf("page number must be greater than 0")
+		return
+	}
+
+	list, err := m.search(WithSortDirection(desc),
+		WithSortField(sortFields[sort]),
+		WithPageNumber(pageNumber))
+	if err != nil {
+		return nil, "", err
+	}
+
+	torrents = m.convertTorrents(list)
+	if list.TotalPages.Value() > pageNumber {
+		nextPageMarker = fmt.Sprintf("%d", pageNumber+1)
+	}
+	return
+}
+
+func (m *Site) SearchTorrents(keyword string, baseUrl string) (torrents []site.Torrent, err error) {
+	list, err := m.search(WithKeyword(keyword))
+	if err == nil {
+		torrents = m.convertTorrents(list)
+	}
+	return
+}
+
+func (m *Site) GetStatus() (*site.Status, error) {
+	var resp ProfileResponse
+	if err := m.do(APIPath_Profile, nil, nil, &resp); err != nil {
+		return nil, err
+	} else {
+		return &site.Status{
+			UserName:            resp.Data.UserName,
+			UserDownloaded:      resp.Data.MemberCount.Downloaded.Value(),
+			UserUploaded:        resp.Data.MemberCount.Uploaded.Value(),
+			TorrentsSeedingCnt:  0,
+			TorrentsLeechingCnt: 0,
+		}, nil
+	}
+}
+
+func (m *Site) PurgeCache() {
+}
+
+func (m *Site) do(path string, query neturl.Values, body any, result any) error {
+	fullPath, err := neturl.JoinPath(m.SiteConfig.Url, path)
+	if err != nil {
+		return err
+	}
+
+	if len(query) > 0 {
+		fullPath = fullPath + "?" + query.Encode()
+	}
+
+	reqHeaders := util.GetHttpReqHeaders(m.GetDefaultHttpHeaders(), m.GetSiteConfig().Cookie, site.GetUa(m))
+	res, err := m.HttpClient.Do(&azuretls.Request{
+		Method:   http.MethodPost,
+		Url:      fullPath,
+		Body:     body,
+		NoCookie: true, // disable azuretls internal cookie jar
+	}, reqHeaders)
+	if err != nil {
+		if _, ok := err.(net.Error); ok {
+			return fmt.Errorf("failed to fetch url: <network error>: %w", err)
+		}
+		return fmt.Errorf("failed to fetch url: %w", err)
+	}
+	log.Tracef("Azuretls.Do response status=%d", res.StatusCode)
+	if res.StatusCode != 200 {
+		return fmt.Errorf("failed to fetch url: status=%d", res.StatusCode)
+	}
+
+	if err := json.Unmarshal(res.Body, result); err != nil {
+		return fmt.Errorf("unmarshal response as json error: %w", err)
+	}
+
+	if c, ok := result.(errorGetter); ok {
+		return c.GetError()
+	}
+
+	return nil
+}
+
+func (m *Site) search(options ...TorrentSearchRequestOption) (list *TorrentList, err error) {
+	req := NewTorrentSearchRequest(options...)
+	var resp TorrentSearchResponse
+	if err = m.do(APIPath_TorrentSearch, nil, req, &resp); err != nil {
+		return
+	}
+
+	list = &resp.Data
+	return
+}
+
+func (m *Site) convertTorrents(list *TorrentList) []site.Torrent {
+	var torrents []site.Torrent
+	for _, torrent := range list.Data {
+		torrents = append(torrents, site.Torrent{
+			Name:               torrent.Name,
+			Description:        torrent.Description,
+			Id:                 fmt.Sprintf("%s.%s", m.Name, torrent.Id),
+			InfoHash:           "",
+			DownloadUrl:        torrent.Id, // can't get download url in list, must call /api/torrent/genDlToken after
+			DownloadMultiplier: getDownloadMultiplier(torrent.Status.Discount),
+			UploadMultiplier:   1.0,
+			DiscountEndTime:    torrent.Status.DiscountEndTime.UnixWithDefault(-1),
+			Time:               torrent.CreateDate.Unix(),
+			Size:               torrent.Size.Value(),
+			IsSizeAccurate:     true,
+			Seeders:            torrent.Status.Seeders.Value(),
+			Leechers:           torrent.Status.Leechers.Value(),
+			Snatched:           0,
+			HasHnR:             false,
+			IsActive:           false, // TODO: maybe torrent.clientList[*].downloaded > 0?
+			Paid:               false,
+			Bought:             false,
+			Neutral:            false,
+		})
+	}
+
+	return torrents
+}
+
+func getDownloadMultiplier(discount string) float64 {
+	switch discount {
+	case TorrentDiscount_70Percent:
+		return 0.3
+	case TorrentDiscount_50Percent:
+		return 0.2
+	case TorrentDiscount_Free:
+		return 0
+	default:
+		return 1
+	}
+}
+
+func NewSite(name string, siteConfig *config.SiteConfigStruct, config *config.ConfigStruct) (site.Site, error) {
+	httpClient, httpHeaders, err := site.CreateSiteHttpClient(siteConfig, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create site http client: %v", err)
+	}
+	s := &Site{
+		Name:        name,
+		SiteConfig:  siteConfig,
+		HttpClient:  httpClient,
+		HttpHeaders: httpHeaders,
+	}
+	return s, nil
+}
+
+func init() {
+	site.Register(&site.RegInfo{
+		Name:    "mtorrent",
+		Creator: NewSite,
+	})
+}

--- a/site/mtorrent/types.go
+++ b/site/mtorrent/types.go
@@ -1,0 +1,149 @@
+package mtorrent
+
+import "fmt"
+
+const (
+	TorrentSearchMode_Normal = "normal"
+	TorrentSearchMode_Adult  = "adult"
+
+	TorrentSearchDirection_Asc  = "ASC"
+	TorrentSearchDirection_Desc = "DESC"
+
+	// Torrent discount
+	TorrentDiscount_Normal    = "NORMAL"
+	TorrentDiscount_50Percent = "PERCENT_50" // 50%
+	TorrentDiscount_70Percent = "PERCENT_70" // 30%
+	TorrentDiscount_Free      = "FREE"       // Free
+)
+
+type ResponseCode struct {
+	Message string `json:"message"`
+	Code    Int64  `json:"code"`
+}
+
+type DownloadTokenResponse struct {
+	ResponseCode
+	Data string `json:"data"`
+}
+
+type TorrentSearchRequest struct {
+	Mode          string   `json:"mode"`
+	Categories    []string `json:"categories"`
+	Visible       int      `json:"visible"`
+	Keyword       string   `json:"keyword,omitempty"`
+	PageNumber    int64    `json:"pageNumber"`
+	PageSize      int      `json:"pageSize"`
+	SortDirection string   `json:"sortDirection,omitempty"`
+	SortField     string   `json:"sortField,omitempty"`
+}
+
+type TorrentSearchRequestOption func(*TorrentSearchRequest)
+
+func WithKeyword(keyword string) TorrentSearchRequestOption {
+	return func(r *TorrentSearchRequest) {
+		r.Keyword = keyword
+	}
+}
+
+func WithMode(mode string) TorrentSearchRequestOption {
+	return func(r *TorrentSearchRequest) {
+		r.Mode = mode
+	}
+}
+
+func WithSortField(field string) TorrentSearchRequestOption {
+	return func(r *TorrentSearchRequest) {
+		r.SortField = field
+	}
+}
+
+func WithPageNumber(pageNumber int64) TorrentSearchRequestOption {
+	return func(r *TorrentSearchRequest) {
+		r.PageNumber = pageNumber
+	}
+}
+
+func WithSortDirection(desc bool) TorrentSearchRequestOption {
+	return func(r *TorrentSearchRequest) {
+		if desc {
+			r.SortDirection = TorrentSearchDirection_Desc
+		} else {
+			r.SortDirection = TorrentSearchDirection_Asc
+		}
+	}
+}
+
+func NewTorrentSearchRequest(opts ...TorrentSearchRequestOption) TorrentSearchRequest {
+	req := TorrentSearchRequest{
+		Mode:       TorrentSearchMode_Normal,
+		Visible:    1,
+		PageNumber: 1,
+		PageSize:   100,
+	}
+	for _, opt := range opts {
+		opt(&req)
+	}
+
+	return req
+}
+
+type TorrentStatus struct {
+	Discount        string `json:"discount"`
+	DiscountEndTime *Time  `json:"discountEndTime"`
+	Leechers        Int64  `json:"leechers"`
+	Seeders         Int64  `json:"seeders"`
+	Status          string `json:"status"`
+}
+
+type Torrent struct {
+	Id               string        `json:"id"`
+	CreateDate       *Time         `json:"createdDate"`
+	LastModifiedDate *Time         `json:"lastModifiedDate"`
+	Name             string        `json:"name"`
+	Description      string        `json:"smallDescr"`
+	Category         string        `json:"category"`
+	Size             Int64         `json:"size"`
+	Status           TorrentStatus `json:"status"`
+}
+
+type TorrentList struct {
+	PageNumber Int64     `json:"pageNumber"`
+	PageSize   Int64     `json:"pageSize"`
+	Total      Int64     `json:"total"`
+	TotalPages Int64     `json:"totalPages"`
+	Data       []Torrent `json:"data"`
+}
+
+type TorrentSearchResponse struct {
+	ResponseCode
+	Data TorrentList `json:"data"`
+}
+
+type Profile struct {
+	Id               string `json:"id"`
+	CreateDate       Time   `json:"createdDate"`
+	LastModifiedDate Time   `json:"lastModifiedDate"`
+	UserName         string `json:"username"`
+	MemberCount      struct {
+		Bonus      float64 `json:"bonus"`
+		Uploaded   Int64   `json:"uploaded"`
+		Downloaded Int64   `json:"downloaded"`
+		ShareRate  float64 `json:"shareRate"`
+	} `json:"memberCount"`
+}
+
+type ProfileResponse struct {
+	ResponseCode
+	Data Profile `json:"data"`
+}
+
+type errorGetter interface {
+	GetError() error
+}
+
+func (r ResponseCode) GetError() error {
+	if r.Code != 0 {
+		return fmt.Errorf("response error(%d): %s", r.Code, r.Message)
+	}
+	return nil
+}

--- a/site/tpl/tpl.go
+++ b/site/tpl/tpl.go
@@ -374,7 +374,7 @@ var (
 			Comment:             "柠檬",
 		},
 		"mteam": {
-			Type:                "nexusphp",
+			Type:                "mtorrent",
 			Aliases:             []string{"m-team", "mt"},
 			Url:                 "https://kp.m-team.cc/",
 			Domains:             []string{"m-team.io"},


### PR DESCRIPTION
fix #20 

introduce a new Site impl: mtorrent.Site, which is able to
1. search torrents
2. get user profile
3. get torrent's real download url

我个人只使用brush命令，`GetAllTorrents`暂未实现