### PR TITLE
feat: limit torrent count per site

### DIFF
--- a/client/transmission/transmission.go
+++ b/client/transmission/transmission.go
@@ -661,7 +661,7 @@ func (trclient *Client) SetConfig(variable string, value string) error {
 			value := argValue.(string)
 			util.SetStructFieldValue(&args, key, &value)
 		} else {
-			return fmt.Errorf("invalid value type: %w", kind)
+			return fmt.Errorf("invalid value type: %v", kind)
 		}
 		return transmissionbt.SessionArgumentsSet(context.TODO(), args)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -198,6 +198,7 @@ type SiteConfigStruct struct {
 	DynamicSeedingTorrentMinSizeValue int64
 	DynamicSeedingTorrentMaxSizeValue int64
 	AutoComment                       string // 自动更新 ptool.toml 时系统生成的 comment。会被写入 Comment 字段
+	BrushAllowAddTorrentsPercent      int    `yaml:"brushAllowAddTorrentsPercent"` // Site种子数量占比(0~100]: ConfigStruct.BrushMaxTorrents; 0 = no limit
 }
 
 type ConfigStruct struct {
@@ -621,6 +622,10 @@ func (siteConfig *SiteConfigStruct) Register() {
 				siteConfig.DynamicSeedingTorrentMinSize, err)
 		}
 		siteConfig.DynamicSeedingTorrentMinSizeValue = v
+	}
+
+	if siteConfig.BrushAllowAddTorrentsPercent < 0 || siteConfig.BrushAllowAddTorrentsPercent > 100 {
+		log.Fatalf("Invalid allowAddTorrentsPercent value %v in site config, should between [0, 100]", siteConfig.BrushAllowAddTorrentsPercent)
 	}
 
 	sitesConfigMap[siteConfig.GetName()] = siteConfig

--- a/util/helper/helper_test.go
+++ b/util/helper/helper_test.go
@@ -93,7 +93,7 @@ func prepareFs(dir string, fs map[string]any) {
 				f.Close()
 			}
 		} else {
-			if err := os.Mkdir(entryPath, 0666); err != nil {
+			if err := os.Mkdir(entryPath, 0777); err != nil {
 				panic(err)
 			}
 			prepareFs(entryPath, entry.(map[string]any))


### PR DESCRIPTION
支持给每个site独立限制torrent数量

```
[[sites]]
name = 'xxx
type = 'xxx'
allowAddTorrentsPercent = 0.5
```

此处allowAddTorrentsPercent是clientConfig.BrushMaxTorrents的比例

不配置的行为和以前一致


我自己的使用场景是防止某些站点占据过多刷流的种子