### PR TITLE
添加AcceptAnyFree选项

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -170,6 +170,7 @@ type SiteConfigStruct struct {
 	BrushAllowZeroSeeders          bool       `yaml:"brushAllowZeroSeeders"`
 	BrushExcludes                  []string   `yaml:"brushExcludes"`
 	BrushExcludeTags               []string   `yaml:"brushExcludeTags"`
+	BrushAcceptAnyFree             bool       `yaml:"brushAcceptAnyFree"`
 	SelectorTorrentsListHeader     string     `yaml:"selectorTorrentsListHeader"`
 	SelectorTorrentsList           string     `yaml:"selectorTorrentsList"`
 	SelectorTorrentBlock           string     `yaml:"selectorTorrentBlock"` // dom block of a torrent in list

--- a/config/ptool.example.toml
+++ b/config/ptool.example.toml
@@ -68,6 +68,7 @@ cookie = 'cookie_here'
 #brushAllowHr = false # 是否允许使用HR种子刷流。程序不会特意保证HR种子的做种时长，所以仅当你的账户无视HR(如VIP)时开启此选项
 #brushAllowZeroSeeders = false # 是否允许刷流任务添加当前0做种的种子到客户端
 #brushExcludes = [] # 排除种子关键字列表。标题或副标题包含列表中任意项的种子不会被刷流任务选择
+#brushAcceptAnyFree = false # 如果种子是免费的，则上传人数下载人数比和发布种子时间rtime的规则不限制
 #timezone = 'Asia/Shanghai' # 网站页面显示时间的时区
 
 # 新版 m-team (馒头) 不支持 Cookie。必须使用 token 鉴权。两种方法选择其一：


### PR DESCRIPTION
有些种子网站比较冷门，经常半天没有一个score>0的合适种子用来刷流，这时候可以采用较为激进的策略，即种子只要免费，就拿来刷流，无视上传人数下载人数比和发种时间。