### PR TITLE
fix: support exact path matching in `PathMapper.Before2After`

### DIFF
--- a/cmd/common/common.go
+++ b/cmd/common/common.go
@@ -104,7 +104,7 @@ func (spm *PathMapper) Before2After(beforePath string) (afterPath string, match 
 			if strings.HasPrefix(beforePath, before) {
 				return spm.mapper[before] + strings.TrimPrefix(beforePath, before), true
 			}
-		} else if strings.HasPrefix(beforePath, before+"/") {
+		} else if beforePath == before || strings.HasPrefix(beforePath, before+"/") {
 			return spm.mapper[before] + strings.TrimPrefix(beforePath, before), true
 		}
 	}

--- a/cmd/shell/shell.go
+++ b/cmd/shell/shell.go
@@ -79,7 +79,7 @@ var ptoolPrompt = &cobraprompt.CobraPrompt{
 
 func shell(command *cobra.Command, args []string) error {
 	if config.InShell {
-		return fmt.Errorf(`you cann't run "shell" command in shell itself`)
+		return fmt.Errorf(`you can't run "shell" command in shell itself`)
 	}
 	if config.Fork || config.LockFile != "" {
 		return fmt.Errorf("--fork or --lock flag can NOT be used with shell")

--- a/cmd/shell/suggest/suggest.go
+++ b/cmd/shell/suggest/suggest.go
@@ -45,7 +45,7 @@ func DirArg(prefix string) []prompt.Suggest {
 func FileArg(prefix string, suffix string, dirOnly bool) []prompt.Suggest {
 	dirprefix := ""
 	dir := "."
-	// cann't use filepath.Dir here as it will discard the leading ./ or ../
+	// can't use filepath.Dir here as it will discard the leading ./ or ../
 	if index := strings.LastIndex(prefix, "/"); index != -1 {
 		dir = prefix[:index]
 		dirprefix = dir + "/"

--- a/cmd/status/api.go
+++ b/cmd/status/api.go
@@ -28,7 +28,7 @@ func fetchClientStatus(clientInstance client.Client, showTorrents bool, showAllT
 	clientStatus, err := clientInstance.GetStatus()
 	response.ClientStatus = clientStatus
 	if err != nil {
-		response.Error = fmt.Errorf("cann't get client %s status: error=%w", clientInstance.GetName(), err)
+		response.Error = fmt.Errorf("can't get client %s status: error=%w", clientInstance.GetName(), err)
 		ch <- response
 		return
 	}
@@ -49,7 +49,7 @@ func fetchClientStatus(clientInstance client.Client, showTorrents bool, showAllT
 		}
 		response.ClientTorrents = clientTorrents
 		if err != nil {
-			response.Error = fmt.Errorf("cann't get client %s torrents: %w", clientInstance.GetName(), err)
+			response.Error = fmt.Errorf("can't get client %s torrents: %w", clientInstance.GetName(), err)
 		}
 	}
 	ch <- response
@@ -65,7 +65,7 @@ func fetchSiteStatus(siteInstance site.Site, showTorrents bool, full bool, showS
 	SiteStatus, err := siteInstance.GetStatus()
 	response.SiteStatus = SiteStatus
 	if err != nil {
-		response.Error = fmt.Errorf("cann't get site %s status: error=%w", siteInstance.GetName(), err)
+		response.Error = fmt.Errorf("can't get site %s status: error=%w", siteInstance.GetName(), err)
 		ch <- response
 		return
 	}
@@ -73,7 +73,7 @@ func fetchSiteStatus(siteInstance site.Site, showTorrents bool, full bool, showS
 	if showTorrents {
 		siteTorrents, err := siteInstance.GetLatestTorrents(full)
 		if err != nil {
-			response.Error = fmt.Errorf("cann't get site %s torrents: %w", siteInstance.GetName(), err)
+			response.Error = fmt.Errorf("can't get site %s torrents: %w", siteInstance.GetName(), err)
 		} else {
 			if showScore {
 				brushSiteOption := strategy.GetBrushSiteOptions(siteInstance, util.Now())

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -82,7 +82,7 @@ func status(cmd *cobra.Command, args []string) error {
 	}
 	if showAll || showAllClients || showAllSites {
 		if len(args) > 0 {
-			return fmt.Errorf("--all, --clients, --sites flags cann't be used with site or client names")
+			return fmt.Errorf("--all, --clients, --sites flags can't be used with site or client names")
 		}
 		if showAll || showAllClients {
 			for _, client := range config.Get().ClientsEnabled {

--- a/cmd/transfertorrent/transfertorrent.go
+++ b/cmd/transfertorrent/transfertorrent.go
@@ -126,7 +126,7 @@ Add torrents to target client in paused state: %t`+"\n", len(torrents), srcClien
 		if savePathMapper != nil {
 			newpath, match := savePathMapper.Before2After(torrent.SavePath)
 			if !match {
-				fmt.Printf("! %s (%s): do not move due to save path cann't be mapped\n", torrent.InfoHash, torrent.Name)
+				fmt.Printf("! %s (%s): do not move due to save path can't be mapped\n", torrent.InfoHash, torrent.Name)
 				continue
 			}
 			targetpapth = newpath

--- a/site/nexusphp/parse.go
+++ b/site/nexusphp/parse.go
@@ -174,9 +174,9 @@ func parseTorrents(doc *goquery.Document, option *TorrentsParserOption,
 	}
 	if containerElNode == nil {
 		if torrentEls.Length() > 1 || option.selectorTorrentsList != "" {
-			err = fmt.Errorf("cann't find torrents list container element")
+			err = fmt.Errorf("can't find torrents list container element")
 		} else {
-			log.Tracef("Cann't find torrents list container element.")
+			log.Tracef("can't find torrents list container element.")
 		}
 		return
 	}
@@ -210,7 +210,7 @@ func parseTorrents(doc *goquery.Document, option *TorrentsParserOption,
 			headerEl = el.Prev()
 		}
 		if headerEl.Length() == 0 {
-			err = fmt.Errorf("cann't find headerEl")
+			err = fmt.Errorf("can't find headerEl")
 			return
 		}
 		log.Tracef("nptr: header node=%v, id=%v, class=%v\n",


### PR DESCRIPTION
**问题描述**
当前`PathMapper.Before2After`函数只支持前缀匹配，无法匹配完全相同的路径，使得在转移种子等功能中，无法转移那些原始种子布局不包含文件夹的种子（提示`do not move due to save path cann't be mapped`）
例如，映射规则`/src/downloads|/dst/downloads` 可以匹配 `/src/downloads/movie`，但无法匹配直接保存在 `/src/downloads` 下的文件 

**变更点**
修改 Before2After 函数的匹配逻辑，增加对完全相同路径的匹配检查 
